### PR TITLE
feat: 로그인 페이지 및 로그인 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
 import MainPage from "@domain/planner/page/MainPage";
 import "./App.css";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import SignInPage from "@domain/auth/page/SignInPage";
+import SignInCallbackPage from "@domain/auth/page/SignInCallBackPage";
+import { ROUTER_PATH } from "@constant/RouterPath";
 
 function App() {
   return (
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<MainPage />} />
+          <Route path={ROUTER_PATH.MAIN} element={<MainPage />} />
+          <Route path={ROUTER_PATH.AUTH.SIGN_IN} element={<SignInPage />} />
+          <Route path={ROUTER_PATH.AUTH.CALLBACK} element={<SignInCallbackPage />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/src/constant/ApiPath.ts
+++ b/src/constant/ApiPath.ts
@@ -1,0 +1,5 @@
+export const API_PATH = {
+  AUTH: {
+    SIGN_IN: "/auth/sign-in"
+  }
+}

--- a/src/constant/RouterPath.ts
+++ b/src/constant/RouterPath.ts
@@ -1,0 +1,8 @@
+export const ROUTER_PATH = {
+    MAIN: `/`,
+    AUTH : {
+        SIGN_IN: `/signin`,
+        CALLBACK: `/callback`,
+    }
+
+}

--- a/src/domain/auth/page/SignInCallBackPage.tsx
+++ b/src/domain/auth/page/SignInCallBackPage.tsx
@@ -1,0 +1,42 @@
+import axios from "axios";
+import queryString from "query-string";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { StoredMemberInfo } from "@domain/auth/type/StoredMemberInfo";
+import { API_PATH } from "@constant/ApiPath";
+import { ROUTER_PATH } from "@constant/RouterPath";
+
+export default function SignInCallbackPage() {
+    const navigate = useNavigate();
+
+  useEffect(() => {
+    const code = queryString.parse(location.search).code;
+    const body = {
+      code: code,
+    };
+
+    axios
+      .post(import.meta.env.VITE_BASE_URL + API_PATH.AUTH.SIGN_IN, 
+      body, 
+      {
+        withCredentials: true
+      })
+      .then(function (response) {
+        if (response.status == 200) {
+            const responseData: StoredMemberInfo = response.data;
+            localStorage.setItem('MEMBER_INFO', JSON.stringify(responseData));
+
+            navigate(ROUTER_PATH.MAIN);
+        } else {
+            throw new Error('Authentication failed');
+        }
+      })
+      .catch(function (error) {
+        console.log('error: {}', error)
+        navigate(ROUTER_PATH.AUTH.SIGN_IN);
+      });
+
+  }, [navigate]);
+
+  return <div></div>;
+}

--- a/src/domain/auth/page/SignInPage.tsx
+++ b/src/domain/auth/page/SignInPage.tsx
@@ -1,0 +1,16 @@
+export default function SignInPage() {
+  function goToGithub() {
+    const url = import.meta.env.VITE_OAUTH_SIGNIN_URL;
+    window.location.href = url;
+  }
+
+  return (
+    <div className="flex flex-col justify-center items-center h-screen">
+      <div className="card w-96 bg-base-200 flex justify-center items-center">
+        <button className="btn btn-neutral btn-wide" onClick={goToGithub}>
+          Github Login
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/domain/auth/type/StoredMemberInfo.ts
+++ b/src/domain/auth/type/StoredMemberInfo.ts
@@ -1,0 +1,5 @@
+export type StoredMemberInfo = {
+  email: string
+  nickName: string;
+  profileUrl: string;
+};

--- a/src/domain/planner/page/MainPage.tsx
+++ b/src/domain/planner/page/MainPage.tsx
@@ -1,7 +1,31 @@
+import { ROUTER_PATH } from "@constant/RouterPath";
+import { StoredMemberInfo } from "@domain/auth/type/StoredMemberInfo";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
 export default function MainPage() {
+
+  const navigate = useNavigate();
+  const [memberInfo, setMemberInfo] = useState<StoredMemberInfo | null>(null);
+
+  useEffect(() => {
+    const storedMemberInfo = localStorage.getItem("MEMBER_INFO");
+    if (storedMemberInfo) {
+      setMemberInfo(JSON.parse(storedMemberInfo));
+    } else {
+      navigate(ROUTER_PATH.AUTH.SIGN_IN);
+      alert("로그인이 필요한 페이지 입니다.");
+      return;
+    }
+  });
+
   return (
     <>
-      <h1>Main Page</h1>
+      <div>
+        <h1>{memberInfo?.nickName}</h1>
+        <h1>{memberInfo?.email}</h1>
+        <h1>{memberInfo?.profileUrl}</h1>
+      </div>
     </>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
       "@domain/*": [
         "src/domain/*"
       ],
+      "@constant/*": [
+        "src/constant/*"
+      ],
     },
 
     "target": "ES2020",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@domain': path.resolve(__dirname, './src/domain'),
+      '@constant': path.resolve(__dirname, './src/constant'),
     },
   },
 })


### PR DESCRIPTION
# ✨ Key changes
- [x] #5 
  
# 👋 To reviewers
1. 로그인 페이지에서 GitHub 로그인 버튼을 클릭한다
2. GitHub 인증 페이지로 이동한다
3. 인증 후 callback 페이지로 redirect 된다
4. callback 페이지에서 API 서버로 로그인 요청을 보낸다
5. 로그인 설공 시 메인 페이지로 이동한다