### PR TITLE
[feat] Layout 개편

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,9 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path={ROUTER_PATH.MAIN} 
-            element={<Layout title={'메인 페이지'}><MainPage /></Layout>} />
+            element={<Layout><MainPage /></Layout>} />
           <Route path={ROUTER_PATH.STUDY.PLANNER} 
-            element={<Layout title={'플래너'}><PlannerMainPage /></Layout>} />
+            element={<Layout><PlannerMainPage /></Layout>} />
           <Route path={ROUTER_PATH.AUTH.SIGN_IN} element={<SignInPage />} />
           <Route path={ROUTER_PATH.AUTH.CALLBACK} element={<SignInCallbackPage />} />
         </Routes>

--- a/src/domain/main/component/Layout.tsx
+++ b/src/domain/main/component/Layout.tsx
@@ -4,37 +4,36 @@ import { ReactNode, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "./header/Header";
 import SideBar from "./sidebar/SideBar";
+import { useDrawerStore } from "../type/DrawerStore";
 
 type Props = {
-    title: string;
-    children: ReactNode;
-  };
-  
-  export default function Layout({ title, children }: Props) {
+  children: ReactNode;
+};
 
-    const navigate = useNavigate();
-    const { isSignIn } = useAuthMemberStore();
-  
-    useEffect(() => {
-      if (!isSignIn()) {
-        navigate(ROUTER_PATH.AUTH.SIGN_IN);
-      }
-    }, []);
+export default function Layout({ children }: Props) {
+  const navigate = useNavigate();
+  const { isSignIn } = useAuthMemberStore();
+  const { isDrawerOpen } = useDrawerStore();
 
-    return (
-      <div className="drawer lg:drawer-open">
-        <input id="my-drawer" type="checkbox" className="drawer-toggle" />
-  
-        <div className="drawer-content flex flex-col items-center justify-start">
-          {/* Header & Content */}
-          <Header title={title} />
-          {children}
-        </div>
-  
-        <div className="drawer-side">
-          <SideBar />
-        </div>
+  useEffect(() => {
+    if (!isSignIn()) {
+      navigate(ROUTER_PATH.AUTH.SIGN_IN);
+    }
+  }, []);
+
+  return (
+    <div className={`drawer ${isDrawerOpen ? 'drawer-open' : ''}`}>
+      <input id="my-drawer" type="checkbox" className="drawer-toggle" />
+
+      <div className="drawer-content">
+        {/* Header & Content */}
+        <Header />
+        {children}
       </div>
-    );
-  }
-  
+
+      <div className="drawer-side">
+        <SideBar />
+      </div>
+    </div>
+  );
+}

--- a/src/domain/main/component/header/AlertButton.tsx
+++ b/src/domain/main/component/header/AlertButton.tsx
@@ -1,0 +1,23 @@
+export default function AlertButton() {
+  return (
+    <button className="btn btn-ghost btn-circle">
+      <div className="indicator">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+          />
+        </svg>
+        <span className="badge badge-xs badge-primary indicator-item"></span>
+      </div>
+    </button>
+  );
+}

--- a/src/domain/main/component/header/Header.tsx
+++ b/src/domain/main/component/header/Header.tsx
@@ -1,74 +1,27 @@
-import { ROUTER_PATH } from "@constant/RouterPath";
-import { useAuthMemberStore } from "@domain/auth/store/AuthMemberStore";
-import { useNavigate } from "react-router-dom";
+import AlertButton from "./AlertButton";
+import HomeButton from "./HomeButton";
+import SearchBar from "./SearchBar";
+import SideBarToggle from "./SideBarToggle";
+import UserInfoButton from "./UserInfoButton";
 
-type Props = {
-  title: string;
-};
-
-export default function Header({ title }: Props) {
-  const navigate = useNavigate();
-  const { storedMemberInfo, signOut } = useAuthMemberStore();
-
-  const fn_signOut = () => {
-    signOut();
-    navigate(ROUTER_PATH.AUTH.SIGN_IN);
-  };
-
+export default function Header() {
   return (
-    <div className="navbar">
-      {/* Open Sidebar */}
-      <div className="navbar-start">
-        <label
-          htmlFor="my-drawer"
-          className="btn btn-square btn-ghost lg:hidden"
-        >
-          // Stack Icon 추가하기
-        </label>
-      </div>
+    <div className="text-base-content sticky top-0 z-30 flex h-16 w-full justify-center bg-opacity-90 backdrop-blur transition-shadow duration-100 [transform:translate3d(0,0,0)]">
+      <div className="navbar bg-base-200">
+        {/* Open/Close Sidebar */}
+        <div className="navbar-start">
+          <SideBarToggle />
+          <HomeButton />
+        </div>
 
-      {/* Page Name */}
-      <div className="navbar-center">
-        <p className="text-3xl font-bold">{title}</p>
-      </div>
+        {/* Center */}
+        <div className="navbar-center"></div>
 
-      {/* User Info */}
-      <div className="navbar-end">
-        <div className="dropdown dropdown-end">
-          <div
-            tabIndex={0}
-            role="button"
-            className="btn btn-ghost btn-circle avatar"
-          >
-            {storedMemberInfo != null ? (
-              <div className="w-10 rounded-full">
-                <img
-                  alt="Tailwind CSS Navbar component"
-                  src={storedMemberInfo && storedMemberInfo.profileUrl}
-                />
-              </div>
-            ) : (
-              <div className="w-10 rounded-full bg-info"></div>
-            )}
-          </div>
-          <ul
-            tabIndex={0}
-            className="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-200 rounded-box w-52"
-          >
-            <li>
-              {storedMemberInfo != null ? (
-                <div>
-                  Welcome!{" "}
-                  <span className="font-bold">{storedMemberInfo.nickName}</span>
-                </div>
-              ) : (
-                <div>회원 정보 없음.</div>
-              )}
-            </li>
-            <li>
-              <a onClick={() => fn_signOut()}>로그 아웃</a>
-            </li>
-          </ul>
+        {/* Search Bar & Alert & User Info */}
+        <div className="navbar-end gap-1">
+          <SearchBar />
+          <AlertButton />
+          <UserInfoButton />
         </div>
       </div>
     </div>

--- a/src/domain/main/component/header/HomeButton.tsx
+++ b/src/domain/main/component/header/HomeButton.tsx
@@ -1,0 +1,20 @@
+export default function HomeButton() {
+  return (
+    <button className="btn btn-square btn-ghost">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/domain/main/component/header/SearchBar.tsx
+++ b/src/domain/main/component/header/SearchBar.tsx
@@ -1,0 +1,11 @@
+export default function SearchBar() {
+  return (
+    <div className="form-control">
+      <input
+        type="text"
+        placeholder="Search"
+        className="input input-bordered w-24 md:w-auto"
+      />
+    </div>
+  );
+}

--- a/src/domain/main/component/header/SideBarToggle.tsx
+++ b/src/domain/main/component/header/SideBarToggle.tsx
@@ -1,0 +1,24 @@
+import { useDrawerStore } from "@domain/main/type/DrawerStore";
+
+export default function SideBarToggle() {
+
+    const { switchDrawerOpen } = useDrawerStore();
+
+  return (
+      <button className="btn btn-square btn-ghost" onClick={switchDrawerOpen}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          className="inline-block w-5 h-5 stroke-current"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M4 6h16M4 12h16M4 18h16"
+          ></path>
+        </svg>
+      </button>
+  );
+}

--- a/src/domain/main/component/header/UserInfoButton.tsx
+++ b/src/domain/main/component/header/UserInfoButton.tsx
@@ -1,0 +1,52 @@
+import { ROUTER_PATH } from "@constant/RouterPath";
+import { useAuthMemberStore } from "@domain/auth/store/AuthMemberStore";
+import { useNavigate } from "react-router-dom";
+
+export default function UserInfoButton() {
+  const navigate = useNavigate();
+  const { storedMemberInfo, signOut } = useAuthMemberStore();
+
+  const fn_signOut = () => {
+    signOut();
+    navigate(ROUTER_PATH.AUTH.SIGN_IN);
+  };
+
+  return (
+    <div className="dropdown dropdown-end">
+      <div
+        tabIndex={0}
+        role="button"
+        className="btn btn-ghost btn-circle avatar"
+      >
+        {storedMemberInfo != null ? (
+          <div className="w-10 rounded-full">
+            <img
+              alt="Tailwind CSS Navbar component"
+              src={storedMemberInfo && storedMemberInfo.profileUrl}
+            />
+          </div>
+        ) : (
+          <div className="w-10 rounded-full bg-info"></div>
+        )}
+      </div>
+      <ul
+        tabIndex={0}
+        className="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-200 rounded-box w-52"
+      >
+        <li>
+          {storedMemberInfo != null ? (
+            <div>
+              Welcome!{" "}
+              <span className="font-bold">{storedMemberInfo.nickName}</span>
+            </div>
+          ) : (
+            <div>회원 정보 없음.</div>
+          )}
+        </li>
+        <li>
+          <a onClick={() => fn_signOut()}>로그 아웃</a>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/domain/main/component/sidebar/SideBar.tsx
+++ b/src/domain/main/component/sidebar/SideBar.tsx
@@ -1,17 +1,8 @@
-import SideBarLogo from "./SideBarLogo";
 import SideBarMenu from "./SideBarMenu";
 
 export default function SideBar() {
     return (
       <>
-        <label
-          htmlFor="my-drawer"
-          aria-label="close sidebar"
-          className="drawer-overlay"
-        ></label>
-  
-        <SideBarLogo />
-  
         <SideBarMenu />
       </>
     );

--- a/src/domain/main/component/sidebar/SideBarLogo.tsx
+++ b/src/domain/main/component/sidebar/SideBarLogo.tsx
@@ -3,7 +3,7 @@ export default function SideBarLogo() {
       <div className="navbar bg-base-200">
         <div className="navbar-start"></div>
         <div className="navbar-center">
-          <a className="btn btn-ghost text-xl">Venus Feeder</a>
+          <a className="btn btn-ghost text-xl">Venus Planner</a>
         </div>
         <div className="navbar-end"></div>
       </div>

--- a/src/domain/main/component/sidebar/SideBarMenu.tsx
+++ b/src/domain/main/component/sidebar/SideBarMenu.tsx
@@ -1,6 +1,7 @@
 import { ROUTER_PATH } from "@constant/RouterPath";
 import { useNavigate } from "react-router-dom";
 import SideBarStudyTree from "./SideBarStudyTree";
+import SideBarLogo from "./SideBarLogo";
 
 export default function SideBarMenu() {
   const navigate = useNavigate();
@@ -11,6 +12,7 @@ export default function SideBarMenu() {
 
   return (
     <ul className="menu p-4 w-80 min-h-full bg-base-200 text-base-content gap-2">
+      <SideBarLogo />
       <li>
         <a
           className="btn btn-success text-lg"

--- a/src/domain/main/type/DrawerStore.ts
+++ b/src/domain/main/type/DrawerStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type DrawerStoreType = {
+  isDrawerOpen: boolean;
+  switchDrawerOpen: () => void;
+};
+
+export const useDrawerStore = create<DrawerStoreType>((set, get) => ({
+  isDrawerOpen: false,
+  switchDrawerOpen: () => {
+    set({ isDrawerOpen: !get().isDrawerOpen });
+  },
+}));

--- a/src/domain/study/component/PlannerCalendar.tsx
+++ b/src/domain/study/component/PlannerCalendar.tsx
@@ -4,10 +4,12 @@ import interactionPlugin from "@fullcalendar/interaction";
 import { useParams } from "react-router-dom";
 import { usePlanStore } from "../store/PlanStore";
 import { useEffect } from "react";
+import { useDrawerStore } from "@domain/main/type/DrawerStore";
 
 export default function PlannerCalendar() {
   const { studyId } = useParams();
   const { plans, planEvents, fetchPlans, isPlansFetched } = usePlanStore();
+  const isDrawerOpen = useDrawerStore(state => state.isDrawerOpen);
 
   useEffect(() => {
     if (!isPlansFetched) {


### PR DESCRIPTION
# ✨ Key changes
#7 

# 👋 To reviewers
## 개편된 레이아웃
<img width="1425" alt="image" src="https://github.com/FlytrapHub/venus-planner-fe/assets/86359180/29d9c581-bd6d-429c-80a0-70fc705105ae">

- 사이드바 열고 닫기 버튼
- 홈 버튼
- 검색 바
- 알림 버튼
- 헤더 고정
- 헤더에 있던 타이틀 제거